### PR TITLE
Updated SDK to allow for C#12 syntax

### DIFF
--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.0",
+    "version": "10.0.104",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
<LangVersion>preview</LangVersion> resolves to the highest language version supported by the installed SDK/compiler.

In older environments this resolved to C# 10, causing C# 12 syntax  to fail. The updated SDK resolves it to C# 12.