### PR TITLE
Add minimum player count setting for KickLevelBelow

### DIFF
--- a/src/Patches/Gameplay/Anticheat/CheckPlayerLevelPatch.cs
+++ b/src/Patches/Gameplay/Anticheat/CheckPlayerLevelPatch.cs
@@ -1,6 +1,6 @@
-﻿using BetterAmongUs.Utilities;
-using BetterAmongUs.Modules;
+﻿using BetterAmongUs.Modules;
 using BetterAmongUs.Patches.Gameplay.UI.Settings;
+using BetterAmongUs.Utilities;
 using HarmonyLib;
 
 namespace BetterAmongUs.Patches.Gameplay.Anticheat;
@@ -20,6 +20,10 @@ internal static class CheckPlayerLevelPatch
             // Kick players below minimum level
             if (!__instance.IsLocalPlayer() && BetterGameSettings.KickLevel.GetBool() && __instance.Data.PlayerLevel < BetterGameSettings.KickLevelBelow.GetInt())
             {
+                var minPlayers = BetterGameSettings.KickLevelBelowMinimumPlayers.GetInt();
+                if (minPlayers > 1 && minPlayers > BAUPlugin.AllPlayerControls.Count)
+                    return;
+                
                 __instance.TryKick(setReasonInfo: $" is level {__instance.Data.PlayerLevel}, level must be equal or above {BetterGameSettings.KickLevelBelow.GetInt()} to join");
             }
         }

--- a/src/Patches/Gameplay/UI/Settings/GameSettingsPatch.cs
+++ b/src/Patches/Gameplay/UI/Settings/GameSettingsPatch.cs
@@ -22,6 +22,7 @@ internal sealed class BetterGameSettings
     internal static OptionIntItem? DetectedLevelAbove;
     internal static OptionCheckboxItem? KickLevel;
     internal static OptionIntItem? KickLevelBelow;
+    internal static OptionIntItem? KickLevelBelowMinimumPlayers;
     internal static OptionCheckboxItem? DetectCheatClients;
     internal static OptionCheckboxItem? DetectInvalidRpcs;
     internal static OptionCheckboxItem? RpcRateLimiting;
@@ -86,6 +87,7 @@ internal static class GameSettingsPatch
             BetterGameSettings.DetectedLevelAbove = OptionIntItem.Create(BetterSettingsTab, TranslationStrings.BetterSetting_Setting_DetectedLevelAbove, (100, 10000, 5), 500, ("Lv ", ""), BetterGameSettings.DetectedLevel);
             BetterGameSettings.KickLevel = OptionCheckboxItem.Create(BetterSettingsTab, TranslationStrings.BetterSetting_Setting_KickLevel, false);
             BetterGameSettings.KickLevelBelow = OptionIntItem.Create(BetterSettingsTab, TranslationStrings.BetterSetting_Setting_KickLevelBelow, (0, 10000, 1), 0, ("Lv ", ""), BetterGameSettings.KickLevel);
+            BetterGameSettings.KickLevelBelowMinimumPlayers = OptionIntItem.Create(BetterSettingsTab, TranslationStrings.BetterSetting_Setting_KickLevelBelowMinimumPlayers, (1, 15, 1), 9, parent: BetterGameSettings.KickLevelBelow);
             BetterGameSettings.DetectCheatClients = OptionCheckboxItem.Create(BetterSettingsTab, TranslationStrings.BetterSetting_Setting_DetectCheatClients, true);
             BetterGameSettings.DetectInvalidRpcs = OptionCheckboxItem.Create(BetterSettingsTab, TranslationStrings.BetterSetting_Setting_DetectInvalidRpcs, true);
             BetterGameSettings.RpcRateLimiting = OptionCheckboxItem.Create(BetterSettingsTab, TranslationStrings.BetterSetting_Setting_RpcRateLimiting, true);

--- a/src/Resources/Lang/en_US.json
+++ b/src/Resources/Lang/en_US.json
@@ -96,6 +96,7 @@
   "BetterSetting.Setting.DetectedLevelAbove": "Detected player level above",
   "BetterSetting.Setting.KickLevel": "Kick player levels",
   "BetterSetting.Setting.KickLevelBelow": "Kick player level below",
+  "BetterSetting.Setting.KickLevelBelowMinimumPlayers": "Only when player count at least",
   "BetterSetting.Setting.DetectCheatClients": "Detect cheat clients",
   "BetterSetting.Setting.DetectInvalidRpcs": "Detect invalid Rpcs",
   "BetterSetting.Setting.RpcRateLimiting": "Rpc Rate Limiting",

--- a/src/build/Generated/TranslationStrings.cs
+++ b/src/build/Generated/TranslationStrings.cs
@@ -474,6 +474,11 @@ public static class TranslationStrings
     public static readonly TranslationString BetterSetting_Setting_KickLevelBelow = new("BetterSetting.Setting.KickLevelBelow");
 
     /// <summary>
+    /// Base Translation: Only when player count at least
+    /// </summary>
+    public static readonly TranslationString BetterSetting_Setting_KickLevelBelowMinimumPlayers = new("BetterSetting.Setting.KickLevelBelowMinimumPlayers");
+
+    /// <summary>
     /// Base Translation: Detect cheat clients
     /// </summary>
     public static readonly TranslationString BetterSetting_Setting_DetectCheatClients = new("BetterSetting.Setting.DetectCheatClients");


### PR DESCRIPTION
This is a very simple QoL feature.
It should make lobbies fill faster by maintaining a high player count.