### PR TITLE
fixed bunch of crashes and other stuff

### DIFF
--- a/src/BAUPlugin.cs
+++ b/src/BAUPlugin.cs
@@ -181,8 +181,11 @@ internal class BAUPlugin : BasePlugin
         ConsoleManager.DetachConsole();
         BetterNotificationManager.Detach();
         ClientPatch.Unpatch();
-        Harmony.UnpatchAll();
-        ModManager.Instance.ModStamp.gameObject.SetActive(false);
+        Harmony.UnpatchSelf();
+        BetterAmongUs.Interfaces.IMonoExtension.ClearExtensions();
+        OptionsMenuBehaviourPatch.RestoreFrameRate();
+        if (ModManager.Instance != null && ModManager.Instance.ModStamp != null)
+            ModManager.Instance.ModStamp.gameObject.SetActive(false);
         SceneChanger.ChangeScene("MainMenu");
     }
 

--- a/src/BetterAmongUs.csproj
+++ b/src/BetterAmongUs.csproj
@@ -6,6 +6,13 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<OutputType>Library</OutputType>
 		<LangVersion>preview</LangVersion>
+		<Version Condition="'$(Version)' == ''">1.3.3</Version>
+		<AssemblyVersion>1.3.3.0</AssemblyVersion>
+		<FileVersion>1.3.3.0</FileVersion>
+		<InformationalVersion>1.3.3</InformationalVersion>
+		<UseGitMetadata Condition="'$(UseGitMetadata)' == '' and (Exists('$(MSBuildProjectDirectory)/../.git') or Exists('$(MSBuildProjectDirectory)/.git'))">true</UseGitMetadata>
+		<UseGitMetadata Condition="'$(UseGitMetadata)' == ''">false</UseGitMetadata>
+		<DefineConstants Condition="'$(UseGitMetadata)' == 'true'">$(DefineConstants);BAU_GIT_METADATA</DefineConstants>
 	</PropertyGroup>
 
 	<!-- Apply Null Notation Restrictions -->
@@ -89,7 +96,7 @@
 
 	<!-- NuGet Info Packages -->
 	<ItemGroup>
-		<PackageReference Include="GitInfo" Version="3.3.3">
+		<PackageReference Include="GitInfo" Version="3.3.3" Condition="'$(UseGitMetadata)' == 'true'">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/Interfaces/IMonoExtension.cs
+++ b/src/Interfaces/IMonoExtension.cs
@@ -68,11 +68,6 @@ internal interface IMonoExtension
 
                 if (baseIsDead || extensionIsDead)
                 {
-                    if (pair.Extension != null && !extensionIsDead)
-                    {
-                        pair.Extension.OnDestroy();
-                    }
-
                     extensions.RemoveAt(i);
                 }
             }
@@ -182,14 +177,6 @@ internal interface IMonoExtension
             return existingComponent;
         }
 
-        var existingExtensions = monoBehaviour.GetComponentsInChildren(Il2CppType.From(typeof(T)), true);
-        if (existingExtensions.Length > 0)
-        {
-            var found = existingExtensions.FirstOrDefault() as T;
-            if (found != null)
-                return found;
-        }
-
         T? monoExtension = monoBehaviour.gameObject.AddComponent<T>();
         if (monoExtension != null)
         {
@@ -224,28 +211,24 @@ internal interface IMonoExtension
         if (monoExtension == null)
             return;
 
-        CleanupLookups();
-
-        if (monoExtension.BaseMono != null)
+        foreach (var entry in _extensionsByBaseType.ToArray())
         {
-            var baseType = monoExtension.BaseMono.GetType();
+            entry.Value.RemoveAll(pair => ReferenceEquals(pair.Extension, monoExtension));
+            if (entry.Value.Count == 0)
+                _extensionsByBaseType.Remove(entry.Key);
+        }
+    }
 
-            if (_extensionsByBaseType.TryGetValue(baseType, out var extensions))
-            {
-                for (int i = extensions.Count - 1; i >= 0; i--)
-                {
-                    if (extensions[i].Extension == monoExtension)
-                    {
-                        extensions.RemoveAt(i);
-                        break;
-                    }
-                }
-
-                if (extensions.Count == 0)
-                {
-                    _extensionsByBaseType.Remove(baseType);
-                }
-            }
+    internal static void ClearExtensions()
+    {
+        var extensions = _extensionsByBaseType.Values.SelectMany(items => items)
+            .Select(pair => pair.Extension).OfType<MonoBehaviour>().ToArray();
+        _extensionsByBaseType.Clear();
+        foreach (var extension in extensions)
+        {
+            if (extension == null) continue;
+            extension.enabled = false;
+            UnityEngine.Object.Destroy(extension);
         }
     }
 

--- a/src/Managers/NetworkManager.cs
+++ b/src/Managers/NetworkManager.cs
@@ -74,14 +74,17 @@ internal static class NetworkManager
 
         MessageReader[] allReaders = writer.MessagesToReaders();
 
-        foreach (MessageReader reader in allReaders)
+        try
         {
-            if (reader.Tag == 5 || reader.Tag == 6)
+            foreach (MessageReader reader in allReaders)
             {
-                ReadData(reader, sendOption);
-                reader.Recycle();
-                continue;
+                if (reader.Tag == 5 || reader.Tag == 6)
+                    ReadData(reader, sendOption);
             }
+        }
+        finally
+        {
+            foreach (var reader in allReaders) reader.Recycle();
         }
     }
 
@@ -103,14 +106,26 @@ internal static class NetworkManager
 
         MessageReader[] allDataReaders = reader.MessagesToReadersNewBuffer();
 
-        foreach (MessageReader dataReader in allDataReaders)
+        try
         {
-            if (dataReader.Tag == 2)
+            foreach (MessageReader dataReader in allDataReaders)
             {
-                var data = ReadRpc(MessageReader.Get(dataReader), typeFlag, ClientId);
-                HandleInnerNetObject(data.Sender, (byte)data.CalledRpc, data.Reader);
-                continue;
+                if (dataReader.Tag != 2) continue;
+                var rpcReader = MessageReader.Get(dataReader);
+                try
+                {
+                    var data = ReadRpc(rpcReader, typeFlag, ClientId);
+                    HandleInnerNetObject(data.Sender, (byte)data.CalledRpc, data.Reader);
+                }
+                finally
+                {
+                    rpcReader.Recycle();
+                }
             }
+        }
+        finally
+        {
+            foreach (var dataReader in allDataReaders) dataReader.Recycle();
         }
     }
 
@@ -143,7 +158,7 @@ internal static class NetworkManager
                 int currentMessageNumber = InnerNetClient.msgNum++;
                 var oldReader = MessageReader.Get(messageReader);
                 InnerNetClient.StartCoroutine(HandleGameDataInner(messageReader, currentMessageNumber));
-                RPCHandler.HandleRPC(parentReader.Tag, null, oldReader, HandlerFlag.HandleGameDataTag);
+                RPCHandler.HandleRPC(oldReader.Tag, null, oldReader, HandlerFlag.HandleGameDataTag);
                 oldReader.Recycle();
             }
         }

--- a/src/ModInfo.cs
+++ b/src/ModInfo.cs
@@ -16,7 +16,11 @@ internal static class ModInfo
     /// <summary>
     /// Gets the Git commit hash from assembly metadata.
     /// </summary>
+#if BAU_GIT_METADATA
     public static string CommitHash = ThisAssembly.Git.Commit;
+#else
+    public static string CommitHash = "source-archive";
+#endif
 
     /// <summary>
     /// Gets the build date from assembly metadata.
@@ -64,7 +68,11 @@ internal static class ModInfo
     /// <summary>
     /// The GitHub repository URL for BAU.
     /// </summary>
+#if BAU_GIT_METADATA
     internal const string GITHUB = ThisAssembly.Git.RepositoryUrl;
+#else
+    internal const string GITHUB = "https://github.com/D1GQ/BetterAmongUs";
+#endif
 
     /// <summary>
     /// The Discord invite URL for BAU.

--- a/src/Modules/AntiCheat/RPCHandlers/ReportDeadBodyHandler.cs
+++ b/src/Modules/AntiCheat/RPCHandlers/ReportDeadBodyHandler.cs
@@ -1,4 +1,4 @@
-using BetterAmongUs.Attributes;
+﻿using BetterAmongUs.Attributes;
 using BetterAmongUs.Generated;
 using BetterAmongUs.Managers;
 using BetterAmongUs.Patches.Gameplay.UI;
@@ -14,13 +14,12 @@ internal sealed class ReportDeadBodyHandler : RPCHandler
 
     internal override bool HandleAntiCheatCancel(PlayerControl? sender, MessageReader reader)
     {
+        if (sender == null || sender.Data == null || sender.MyPhysics == null)
+            return CancelAsHost;
+
         if (!GameState.IsInGamePlay || !BAUPlugin.AllPlayerControls.All(pc => pc.roleAssigned))
         {
-            if (BetterNotificationManager.NotifyCheat(sender, TranslationStrings.AntiCheat_InvalidActionRPC.Format(Enum.GetName((RpcCalls)CallId)), forceBan: true))
-            {
-                LogRpcInfo($"Report dead body blocked: Game not in play or roles not assigned");
-            }
-
+            // Late packets during loading or teardown are not evidence of cheating.
             return CancelAsHost;
         }
 
@@ -41,7 +40,12 @@ internal sealed class ReportDeadBodyHandler : RPCHandler
 
         if (isBodyReport)
         {
-            if (!deadPlayerInfo.IsDead || deadPlayerInfo == sender.Data)
+            if (!deadPlayerInfo.IsDead && deadPlayerInfo != sender.Data)
+            {
+                return true;
+            }
+
+            if (deadPlayerInfo == sender.Data)
             {
                 if (BetterNotificationManager.NotifyCheat(sender, TranslationStrings.AntiCheat_InvalidActionRPC.Format(Enum.GetName((RpcCalls)CallId))))
                 {

--- a/src/Modules/AntiCheat/RPCHandlers/SendChatHandler.cs
+++ b/src/Modules/AntiCheat/RPCHandlers/SendChatHandler.cs
@@ -1,4 +1,4 @@
-using AmongUs.Data;
+﻿using AmongUs.Data;
 using BetterAmongUs.Attributes;
 using BetterAmongUs.Data;
 using BetterAmongUs.Utilities;
@@ -17,9 +17,11 @@ internal sealed class SendChatHandler : RPCHandler
     {
         var text = reader.ReadString();
 
+        if (sender == null || !GameState.IsHost || sender.IsLocalPlayer()) return;
+
         if (BetterGameSettings.UseBanWordList.GetBool() && (!BetterGameSettings.UseBanWordListOnlyLobby.GetBool() || GameState.IsLobby))
         {
-            if (TextFileHandler.CompareStringFilters(BetterDataManager.Files.banWordListFilePath, text.Split(' ')))
+            if (TextFileHandler.CompareChatFilters(BetterDataManager.Files.banWordListFilePath, text))
             {
                 sender.Kick(false, $"has been kicked due to\nchat message containing a banned word!");
             }
@@ -28,7 +30,7 @@ internal sealed class SendChatHandler : RPCHandler
 
     internal override void HandleAntiCheat(PlayerControl? sender, MessageReader reader)
     {
-        if (sender.IsAlive() && GameState.IsInGamePlay && !GameState.IsMeeting && !GameState.IsExilling || DataManager.Settings.Multiplayer.ChatMode == InnerNet.QuickChatModes.QuickChatOnly)
+        if (sender.IsAlive() && GameState.IsInGamePlay && !GameState.IsMeeting && !GameState.IsExilling)
         {
             if (BetterNotificationManager.NotifyCheat(sender, GetFormatActionText()))
             {

--- a/src/Modules/ClientOptionItem.cs
+++ b/src/Modules/ClientOptionItem.cs
@@ -1,6 +1,7 @@
 ﻿using BepInEx.Configuration;
 using BetterAmongUs.Generated;
 using BetterAmongUs.Patches.Client;
+using BetterAmongUs.Utilities;
 using BetterAmongUs.Utilities.Extension;
 using UnityEngine;
 
@@ -84,7 +85,9 @@ internal sealed class ClientOptionItem
         var mouseMoveToggle = optionsMenuBehaviour.DisableMouseMovement;
         var toggleButton = UnityEngine.Object.Instantiate(mouseMoveToggle, parent);
         toggleButton.name = translationStringName.LocalizedString;
+        toggleButton.DestroyTextTranslators();
         toggleButton.Text.text = translationStringName.LocalizedString;
+        toggleButton.gameObject.SetActive(true);
 
         return toggleButton;
     }
@@ -165,7 +168,7 @@ internal sealed class ClientOptionItem
 
         // Style for button (not toggle)
         ToggleButton.Text.text = ToggleButton.name;
-        ToggleButton.Rollover?.ChangeOutColor(new Color32(0, 150, 0, 255));
+        if (ToggleButton.Rollover != null) ToggleButton.Rollover.ChangeOutColor(new Color32(0, 150, 0, 255));
         ToggleButton.Text.color = new Color(1f, 1f, 1f, 1f);
 
         passiveButton.OnClick.AddListener(() =>
@@ -202,7 +205,7 @@ internal sealed class ClientOptionItem
             new Color(1f, 1f, 1f, 0.5f);
 
         ToggleButton.Background.color = color;
-        ToggleButton.Rollover?.ChangeOutColor(color);
+        if (ToggleButton.Rollover != null) ToggleButton.Rollover.ChangeOutColor(color);
         ToggleButton.Text.color = textColor;
         ToggleButton.Text.text = $"{ToggleButton.name}: {(isEnabled ? "On" : "Off")}";
     }

--- a/src/Modules/OptionItems/OptionCheckboxItem.cs
+++ b/src/Modules/OptionItems/OptionCheckboxItem.cs
@@ -90,6 +90,8 @@ public sealed class OptionCheckboxItem : OptionItem<bool>
     /// <param name="updateTabVisuals">Whether to update the parent tab visuals as well.</param>
     internal sealed override void UpdateVisuals(bool updateTabVisuals = true)
     {
+        if (Option == null || Tab == null || Tab.AUTab == null) return;
+
         if (Option is ToggleOption toggleOption)
         {
             toggleOption.CheckMark.enabled = Value;

--- a/src/Modules/OptionItems/OptionFloatItem.cs
+++ b/src/Modules/OptionItems/OptionFloatItem.cs
@@ -164,6 +164,8 @@ public class OptionFloatItem : OptionItem<float>
     /// <param name="updateTabVisuals">Whether to update the parent tab visuals as well.</param>
     internal override void UpdateVisuals(bool updateTabVisuals = true)
     {
+        if (Option == null || Tab == null || Tab.AUTab == null) return;
+
         if (Option is NumberOption numberOption)
         {
             numberOption.PlusBtn.SetInteractable(false);

--- a/src/Modules/OptionItems/OptionIntItem.cs
+++ b/src/Modules/OptionItems/OptionIntItem.cs
@@ -163,6 +163,8 @@ public sealed class OptionIntItem : OptionItem<int>
     /// <param name="updateTabVisuals">Whether to update the parent tab visuals as well.</param>
     internal sealed override void UpdateVisuals(bool updateTabVisuals = true)
     {
+        if (Option == null || Tab == null || Tab.AUTab == null) return;
+
         if (Option is NumberOption numberOption)
         {
             numberOption.PlusBtn.SetInteractable(false);

--- a/src/Modules/OptionItems/OptionPlayerItem.cs
+++ b/src/Modules/OptionItems/OptionPlayerItem.cs
@@ -18,7 +18,7 @@ public sealed class OptionPlayerItem : OptionItem<int>
     /// <summary>
     /// Gets the maximum player index based on the number of players in the game.
     /// </summary>
-    private int Max => BAUPlugin.AllPlayerControls.Count - 1;
+    private int Max => Math.Max(Min, BAUPlugin.AllPlayerControls.Count - 1);
 
     /// <summary>
     /// Gets the minimum player index (-1 for random selection, 0 for first player).
@@ -204,6 +204,8 @@ public sealed class OptionPlayerItem : OptionItem<int>
     /// <param name="updateTabVisuals">Whether to update the parent tab visuals as well.</param>
     internal sealed override void UpdateVisuals(bool updateTabVisuals = true)
     {
+        if (Option == null || Tab == null || Tab.AUTab == null) return;
+
         if (!GameSettingMenu.Instance)
             return;
 

--- a/src/Modules/OptionItems/OptionStringItem.cs
+++ b/src/Modules/OptionItems/OptionStringItem.cs
@@ -131,6 +131,8 @@ public class OptionStringItem : OptionItem<int>
     /// <param name="updateTabVisuals">Whether to update the parent tab visuals as well.</param>
     internal sealed override void UpdateVisuals(bool updateTabVisuals = true)
     {
+        if (Option == null || Tab == null || Tab.AUTab == null) return;
+
         if (Option is NumberOption numberOption)
         {
             numberOption.PlusBtn.SetInteractable(false);

--- a/src/Modules/OptionItems/OptionTab.cs
+++ b/src/Modules/OptionItems/OptionTab.cs
@@ -34,7 +34,7 @@ internal sealed class OptionTab
     /// <summary>
     /// Gets the translated description of this tab.
     /// </summary>
-    internal string Description => TranslationName.LocalizedString;
+    internal string Description => TranslationDescription.LocalizedString;
 
     /// <summary>
     /// Gets or sets the translation key for the tab description.
@@ -131,6 +131,7 @@ internal sealed class OptionTab
 
         var SettingsTab = UnityEngine.Object.Instantiate(GameSettingMenu.Instance.GameSettingsTab, GameSettingMenu.Instance.GameSettingsTab.transform.parent);
         AUTab = SettingsTab;
+        SettingsTab.enabled = false;
         SettingsTab.name = Name;
         if (!doNotDestroyMapPicker) SettingsTab.scrollBar.Inner.DestroyChildren();
 
@@ -197,8 +198,11 @@ internal sealed class OptionTab
             opt.UpdateVisuals(false);
         }
 
-        AUTab?.scrollBar?.SetYBoundsMax(spacingNum - 2.5f);
-        AUTab?.scrollBar?.ScrollRelative(new(0f, 0f));
+        if (AUTab.scrollBar != null)
+        {
+            AUTab.scrollBar.SetYBoundsMax(Mathf.Max(0f, spacingNum - 2.5f));
+            AUTab.scrollBar.ScrollRelative(new(0f, 0f));
+        }
     }
 
     /// <summary>

--- a/src/Modules/TextFileHandler.cs
+++ b/src/Modules/TextFileHandler.cs
@@ -66,22 +66,42 @@ internal static class TextFileHandler
         if (File.Exists(filePath))
         {
             return File.ReadLines(filePath)
+                       .Select(line => line.Trim())
                        .Where(line => !string.IsNullOrWhiteSpace(line) &&
                               !line.StartsWith("//") &&
                               !line.StartsWith("#"))
                        .SelectMany(line => line.Split(',', StringSplitOptions.RemoveEmptyEntries)
-                                               .Select(s => s.Trim()));
+                                               .Select(s => s.Trim()))
+                       .Where(entry => entry.Length > 0);
         }
 
         return [];
     }
 
     /// <summary>
-    /// Checks if a text matches a filter pattern with wildcard support.
+    /// Matches a chat message against configured words, phrases and wildcard filters.
     /// </summary>
-    /// <param name="filter">The filter pattern (supports ** wildcards).</param>
-    /// <param name="text">The text to check.</param>
-    /// <returns>True if the text matches the filter pattern, false otherwise.</returns>
+    internal static bool CompareChatFilters(string filePath, string text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        var words = Regex.Matches(text, @"[\p{L}\p{N}_]+(?:['’][\p{L}\p{N}_]+)*")
+            .Cast<Match>().Select(match => match.Value).ToArray();
+        foreach (var filter in ReadContents(filePath))
+        {
+            if (CheckFilterString(filter, text.Trim()) || words.Any(word => CheckFilterString(filter, word)))
+                return true;
+
+            // Also support multi-word entries inside a longer message.
+            if (filter.Any(char.IsWhiteSpace))
+            {
+                int count = filter.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
+                for (int i = 0; i + count <= words.Length; i++)
+                    if (CheckFilterString(filter, string.Join(" ", words.Skip(i).Take(count)))) return true;
+            }
+        }
+        return false;
+    }
+
     private static bool CheckFilterString(string filter, string text)
     {
         string pattern = filter switch

--- a/src/MonoScripts/Extended/ExtendedPassiveButton.cs
+++ b/src/MonoScripts/Extended/ExtendedPassiveButton.cs
@@ -47,7 +47,7 @@ internal class ExtendedPassiveButton : MonoBehaviour, IMonoExtension<PassiveButt
 
     public void Update()
     {
-        if (m_isHolding)
+        if (m_isHolding && BaseMono != null)
         {
             m_holdTimer += Time.deltaTime;
             if (m_holdTimer >= HoldTriggerTime)
@@ -55,6 +55,13 @@ internal class ExtendedPassiveButton : MonoBehaviour, IMonoExtension<PassiveButt
                 BaseMono.ReceiveClickUp();
             }
         }
+    }
+
+    public void OnDisable()
+    {
+        m_isHolding = false;
+        m_suppressClick = false;
+        m_holdTimer = 0f;
     }
 
     public void OnDestroy()

--- a/src/Patches/Client/ClientPatch.cs
+++ b/src/Patches/Client/ClientPatch.cs
@@ -100,11 +100,13 @@ internal static class ClientPatch
 
     private static IEnumerator CoMovePlayerData()
     {
-        foreach (var data in GameData.Instance.AllPlayers)
+        if (GameData.Instance == null) yield break;
+        var gameData = GameData.Instance;
+        var players = new List<NetworkedPlayerInfo>();
+        foreach (var player in gameData.AllPlayers) players.Add(player);
+        foreach (var data in players)
         {
-            if (data == null || data.gameObject == null)
-                continue;
-
+            if (data == null || data.gameObject == null) continue;
             UnityEngine.Object.DontDestroyOnLoad(data.gameObject);
         }
 
@@ -115,7 +117,7 @@ internal static class ClientPatch
 
         if (SceneManager.GetActiveScene().name == "EndGame")
         {
-            foreach (var data in GameData.Instance.AllPlayers)
+            foreach (var data in players)
             {
                 if (data == null || data.gameObject == null)
                     continue;
@@ -125,14 +127,15 @@ internal static class ClientPatch
         }
         else
         {
-            foreach (var data in GameData.Instance.AllPlayers)
+            foreach (var data in players)
             {
                 if (data == null || data.gameObject == null)
                     continue;
 
                 UnityEngine.Object.Destroy(data.gameObject);
             }
-            GameData.Instance.AllPlayers.Clear();
+            if (gameData != null && GameData.Instance == gameData)
+                gameData.AllPlayers.Clear();
         }
     }
 

--- a/src/Patches/Client/InnerNetClientPatch.cs
+++ b/src/Patches/Client/InnerNetClientPatch.cs
@@ -61,7 +61,9 @@ internal static class InnerNetClientPatch
         if (ban && BetterGameSettings.UseBanPlayerList.GetBool())
         {
             // Get player info from client ID
-            NetworkedPlayerInfo info = Utils.PlayerFromClientId(clientId).Data;
+            var player = Utils.PlayerFromClientId(clientId);
+            if (player == null || player.Data == null) return;
+            NetworkedPlayerInfo info = player.Data;
 
             // Add player to ban list using both friend code and PUID
             BetterDataManager.AddToBanList(info.FriendCode, info.Puid);

--- a/src/Patches/Client/Managers/ModManagerPatch.cs
+++ b/src/Patches/Client/Managers/ModManagerPatch.cs
@@ -61,6 +61,8 @@ internal static class ModManagerPatch
             }
         }
 
+        OptionsMenuBehaviourPatch.UpdateFrameRate();
+
         // Update various BAU systems each frame
         BetterAntiCheat.Update();
         BetterNotificationManager.Update();

--- a/src/Patches/Client/OptionsMenuBehaviourPatch.cs
+++ b/src/Patches/Client/OptionsMenuBehaviourPatch.cs
@@ -20,11 +20,19 @@ namespace BetterAmongUs.Patches.Client;
 internal static class OptionsMenuBehaviourPatch
 {
     internal static TabGroup? BetterOptionsTab { get; private set; }
+    private static int? taskVSyncCount;
 
     [HarmonyPatch(typeof(OptionsMenuBehaviour), nameof(OptionsMenuBehaviour.Start))]
     [HarmonyPostfix]
     private static void Start_Postfix(OptionsMenuBehaviour __instance)
     {
+        if (__instance.DisableMouseMovement == null || __instance.Tabs == null || __instance.Tabs.Length == 0)
+            return;
+
+        var template = __instance.Tabs[^1];
+        if (template == null || template.Content == null || template.GetComponent<PassiveButton>() == null)
+            return;
+
         // Create custom "Better Options" tab in settings menu
         BetterOptionsTab = CreateTabPage(__instance, TranslationStrings.BetterOption.LocalizedString);
 
@@ -110,8 +118,28 @@ internal static class OptionsMenuBehaviourPatch
 
     internal static void UpdateFrameRate()
     {
-        // Toggle between 60 FPS (default) and 165 FPS
-        Application.targetFrameRate = BAUConfigs.UnlockFPS.Value ? 999 : 60;
+        bool taskOpen = Minigame.Instance != null && Minigame.Instance.isActiveAndEnabled;
+        if (taskOpen)
+        {
+            if (!taskVSyncCount.HasValue) taskVSyncCount = QualitySettings.vSyncCount;
+            QualitySettings.vSyncCount = 0;
+        }
+        else if (taskVSyncCount.HasValue)
+        {
+            QualitySettings.vSyncCount = taskVSyncCount.Value;
+            taskVSyncCount = null;
+        }
+        int target = BAUConfigs.UnlockFPS.Value && !taskOpen ? 165 : 60;
+        if (Application.targetFrameRate != target)
+            Application.targetFrameRate = target;
+    }
+
+    internal static void RestoreFrameRate()
+    {
+        if (taskVSyncCount.HasValue)
+            QualitySettings.vSyncCount = taskVSyncCount.Value;
+        taskVSyncCount = null;
+        Application.targetFrameRate = 60;
     }
 
     private static void OpenSaveData()
@@ -164,7 +192,8 @@ internal static class OptionsMenuBehaviourPatch
         // Create content container for the new tab
         var content = new GameObject($"{name}Tab");
         content.SetActive(false);
-        content.transform.SetParent(tab.Content.transform.parent);
+        content.transform.SetParent(tab.Content.transform.parent, false);
+        content.transform.localPosition = tab.Content.transform.localPosition;
         content.transform.localScale = Vector3.one;
         tab.Content = content;
 
@@ -178,7 +207,8 @@ internal static class OptionsMenuBehaviourPatch
         button.OnClick = new();
         button.OnClick.AddListener(() =>
         {
-            tab.Rollover.SetEnabledColors();
+            if (tab == null || __instance == null) return;
+            if (tab.Rollover != null) tab.Rollover.SetEnabledColors();
             __instance.OpenTabGroup(index);
         });
 
@@ -196,7 +226,7 @@ internal static class OptionsMenuBehaviourPatch
         int activeCount = 0;
         foreach (var tabButton in __instance.Tabs)
         {
-            if (tabButton.gameObject.activeInHierarchy) activeCount++;
+            if (tabButton != null && tabButton.gameObject.activeInHierarchy) activeCount++;
         }
 
         if (activeCount == 0)
@@ -210,7 +240,7 @@ internal static class OptionsMenuBehaviourPatch
         int activeIndex = 0;
         foreach (var tabButton in __instance.Tabs)
         {
-            if (!tabButton.gameObject.activeInHierarchy) continue;
+            if (tabButton == null || !tabButton.gameObject.activeInHierarchy) continue;
 
             float xPos = startX + activeIndex * (buttonWidth + buttonSpacing);
             tabButton.transform.localPosition = new Vector3(xPos, basePos.y, basePos.z);

--- a/src/Patches/Gameplay/Anticheat/InitializePlayerTimeoutPatch.cs
+++ b/src/Patches/Gameplay/Anticheat/InitializePlayerTimeoutPatch.cs
@@ -1,5 +1,7 @@
 ﻿using BepInEx.Unity.IL2CPP.Utils.Collections;
 using BetterAmongUs.Generated;
+using BetterAmongUs.Data.Config;
+using BetterAmongUs.Modules.Support;
 using BetterAmongUs.Modules;
 using BetterAmongUs.Utilities;
 using HarmonyLib;
@@ -14,6 +16,9 @@ internal static class InitializePlayerTimeoutPatch
     [HarmonyPostfix]
     private static void PlayerControl_ClientInitialize_Postfix(PlayerControl __instance, ref Il2CppSystem.Collections.IEnumerator __result)
     {
+        if (!BAUConfigs.AntiCheat.Value || BAUModdedSupportFlags.HasFlag(BAUModdedSupportFlags.Disable_Anticheat))
+            return;
+
         __result = CoClientInitialize(__instance, __result).WrapToIl2Cpp();
     }
 
@@ -21,35 +26,15 @@ internal static class InitializePlayerTimeoutPatch
     {
         player.Visible = false;
         bool exit = false;
-        yield return player.AssertWithTimeout((Func<bool>)(() => GameData.Instance != null && player.Data != null && !player.Data.IsIncomplete), (Action)(() =>
+        yield return player.AssertWithTimeout((Func<bool>)(() => player == null || (GameData.Instance != null && player.Data != null && !player.Data.IsIncomplete)), (Action)(() =>
         {
-            if (GameState.IsHost)
-            {
-                player.Kick(true, TranslationStrings.AntiCheat_Reason_Initialize.LocalizedString, true, forceBan: true);
-                exit = true;
-            }
-            else
-            {
-                if (GameData.Instance != null && player.Data != null)
-                {
-                    player.Data.PlayerLevel = 0;
-                    var outfit = player.Data.DefaultOutfit;
-                    outfit.PlayerName = TranslationStrings.Player_Loading.LocalizedString;
-                    outfit.HatId = HatData.EmptyId;
-                    outfit.VisorId = VisorData.EmptyId;
-                    outfit.SkinId = SkinData.EmptyId;
-                    outfit.PetId = PetData.EmptyId;
-                    outfit.NamePlateId = NamePlateData.EmptyId;
-                    outfit.ColorId = 18;
-                }
-                else
-                {
-                    exit = true;
-                }
-            }
+            exit = GameState.IsHost && player != null && !player.AmOwner;
+            if (player != null && GameState.IsHost && !player.AmOwner)
+                player.Kick(false, TranslationStrings.AntiCheat_Reason_Initialize.LocalizedString,
+                    bypassDataCheck: true);
         }), 25f);
 
-        if (exit)
+        if (exit || player == null)
         {
             yield break;
         }

--- a/src/Patches/Gameplay/Player/CosmeticsLayerPatch.cs
+++ b/src/Patches/Gameplay/Player/CosmeticsLayerPatch.cs
@@ -17,7 +17,12 @@ internal static class CosmeticsLayerPatch
         }
 
         // Skip for custom colors not in vanilla palette
-        if (__instance.bodyMatProperties.ColorId > Palette.PlayerColors.Length) return true;
+        int colorId = __instance.bodyMatProperties.ColorId;
+        if (colorId < 0 || colorId >= Palette.PlayerColors.Length)
+        {
+            __result = string.Empty;
+            return false;
+        }
 
         // Get color name from palette
         string colorName = Palette.GetColorName(__instance.bodyMatProperties.ColorId);

--- a/src/Patches/Gameplay/Player/PlayerJoinAndLeftPatch.cs
+++ b/src/Patches/Gameplay/Player/PlayerJoinAndLeftPatch.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using BepInEx.Unity.IL2CPP.Utils;
 using BetterAmongUs.Data;
 using BetterAmongUs.Data.Config;
@@ -25,9 +25,10 @@ internal static class PlayerJoinAndLeftPatch
         // Fix host icon color display on modded servers
         if (!GameState.IsVanillaServer)
         {
-            var host = AmongUsClient.Instance.GetHost().Character;
-            host?.SetColor(-2);
-            host?.SetColor(host.CurrentOutfit.ColorId);
+            var hostClient = AmongUsClient.Instance.GetHost();
+            var host = hostClient != null ? hostClient.Character : null;
+            if (host != null && host.cosmetics != null)
+                host.cosmetics.SetColor(host.CurrentOutfit.ColorId);
         }
 
         Logger_.Log($"Successfully joined {GameCode.IntToGameName(AmongUsClient.Instance.GameId)}", "OnGameJoinedPatch");

--- a/src/Patches/Gameplay/UI/PlayerTabPatch.cs
+++ b/src/Patches/Gameplay/UI/PlayerTabPatch.cs
@@ -118,7 +118,7 @@ internal static class PlayerTabPatch
         foreach (var icon in _favoriteIcons)
         {
             if (icon == null) continue;
-            UnityEngine.Object.Destroy(icon);
+            UnityEngine.Object.Destroy(icon.gameObject);
         }
         _favoriteIcons.Clear();
 
@@ -130,7 +130,8 @@ internal static class PlayerTabPatch
 
             // Override click behavior
             var extendedPassiveButton = IMonoExtension.AddExtension<ExtendedPassiveButton>(colorChip.Button);
-            extendedPassiveButton.OnHoldOrShiftClick += () =>
+            if (extendedPassiveButton == null) continue;
+            extendedPassiveButton.OnHoldOrShiftClick = () =>
             {
                 if (BAUConfigs.FavoriteColor.Value == index)
                 {
@@ -145,7 +146,13 @@ internal static class PlayerTabPatch
             };
 
             // Add favorite star indicator
-            var checkBox = colorChip.PlayerEquippedForeground.transform.Find("CheckMark").GetComponentInChildren<SpriteRenderer>();
+            var checkMark = colorChip.PlayerEquippedForeground.transform.Find("CheckMark");
+            var checkBox = checkMark != null ? checkMark.GetComponentInChildren<SpriteRenderer>() : null;
+            if (checkBox == null)
+            {
+                _favoriteIcons.Add(null);
+                continue;
+            }
             var favoriteIcon = UnityEngine.Object.Instantiate(checkBox, colorChip.transform);
             favoriteIcon.color = Color.yellow;
             favoriteIcon.transform.localPosition -= new Vector3(0f, 0f, 15f);
@@ -161,6 +168,7 @@ internal static class PlayerTabPatch
         for (int i = 0; i < _favoriteIcons.Count; i++)
         {
             SpriteRenderer? fav = _favoriteIcons[i];
+            if (fav == null) continue;
             fav.gameObject.SetActive(i == BAUConfigs.FavoriteColor.Value);
         }
     }

--- a/src/Patches/Gameplay/UI/Settings/GameSettingsPatch.cs
+++ b/src/Patches/Gameplay/UI/Settings/GameSettingsPatch.cs
@@ -52,6 +52,7 @@ internal static class GameSettingsPatch
     // Creates all custom game settings and organizes them in tabs
     internal static void SetupSettings(bool IsPreload = false)
     {
+        OptionItem.AllOptionsTemp.Clear();
         // Note: Use 2200 next ID
 
         // Create main settings tab
@@ -114,7 +115,8 @@ internal static class GameSettingsPatch
 
         // Adjust menu layout
         __instance.gameObject.transform.SetLocalY(-0.1f);
-        GameObject PanelSprite = __instance.gameObject.transform.Find("PanelSprite").gameObject;
+        var panelTransform = __instance.gameObject.transform.Find("PanelSprite");
+        GameObject? PanelSprite = panelTransform != null ? panelTransform.gameObject : null;
         if (PanelSprite != null)
         {
             PanelSprite.transform.SetLocalY(-0.32f);
@@ -190,7 +192,7 @@ internal static class GameSettingsPatch
         if (BAUModdedSupportFlags.HasFlag(BAUModdedSupportFlags.Disable_AllGameOptions)) return true;
 
         // Skip creation if this is our custom tab
-        if (__instance == BetterSettingsTab.AUTab)
+        if (BetterSettingsTab != null && __instance == BetterSettingsTab.AUTab)
         {
             return false;
         }

--- a/src/Utilities/PlayerControlUtils.cs
+++ b/src/Utilities/PlayerControlUtils.cs
@@ -140,7 +140,16 @@ internal static class PlayerControlUtils
     internal static void Kick(this PlayerControl player, bool ban = false, string setReasonInfo = "", bool antiCheatBan = false, bool bypassDataCheck = false, bool forceBan = false)
     {
         if (!player.CanKick(ban, antiCheatBan, bypassDataCheck, forceBan, out var shouldBan)) return;
-        KickCooldownManager.ScheduleAction(() => { player.PerformKick(shouldBan, setReasonInfo, antiCheatBan); });
+        var client = AmongUsClient.Instance;
+        int gameId = client.GameId;
+        int clientId = player.GetClientId();
+        KickCooldownManager.ScheduleAction(() =>
+        {
+            if (client == null || AmongUsClient.Instance != client || client.GameId != gameId ||
+                player == null || player.GetClientId() != clientId ||
+                !player.CanKick(ban, antiCheatBan, bypassDataCheck, forceBan, out var currentBan)) return;
+            player.PerformKick(currentBan, setReasonInfo, antiCheatBan);
+        });
     }
 
     /// <summary>
@@ -195,7 +204,7 @@ internal static class PlayerControlUtils
     {
         shouldBan = ban || forceBan;
 
-        if (!GameState.IsHost || player.IsLocalPlayer() || (!player.DataIsCollected() && !bypassDataCheck) || player.IsHost() || player.isDummy)
+        if (player == null || !GameState.IsHost || player.IsLocalPlayer() || (!player.DataIsCollected() && !bypassDataCheck) || player.IsHost() || player.isDummy)
             return false;
 
         if (forceBan || !antiCheatBan) return true;
@@ -227,14 +236,18 @@ internal static class PlayerControlUtils
     /// <param name="antiCheatBan">Whether this is an anti-cheat related kick.</param>
     private static void PerformKick(this PlayerControl player, bool ban = false, string setReasonInfo = "", bool antiCheatBan = false)
     {
-        if (setReasonInfo != "")
+        if (player == null || !GameState.IsHost) return;
+
+        if (player.ExtendedData() != null)
+            player.ExtendedData().AntiCheatInfo.BannedByAntiCheat = antiCheatBan;
+
+        if (player.Data != null && setReasonInfo != "")
         {
             PlayerJoinAndLeftPatch.BetterShowNotification(player.Data, forceReasonText: string.Format(setReasonInfo, ban ? TranslationStrings.AntiCheat_Ban.LocalizedString.ToLower() : TranslationStrings.AntiCheat_Kick.LocalizedString.ToLower()));
         }
 
         AmongUsClient.Instance.KickPlayer(player.GetClientId(), ban);
 
-        player.ExtendedData().AntiCheatInfo.BannedByAntiCheat = antiCheatBan;
     }
 
     /// <summary>


### PR DESCRIPTION
| Report | Changes / status |
| --- | --- |
| #123, #101 — Settings crashes | Removed recursive extension cleanup, added checks for destroyed UI objects, stopped the cloned settings component from updating removed controls, and cleared temporary options when rebuilding. |
| #120 — Transition crashes | Fixed invalid palette indexing, preserved player-data references across scene changes, and rechecked queued kicks before execution. The Innersloth anti-cheat message remains unresolved. |
| #119 — Fast self-report detections | Reports no longer trigger a penalty solely because the victim’s death state has not updated locally. The host’s original handler validates the report. Reports during loading or teardown no longer force a ban. |
| #118 — Chat filter | Added support for punctuation, Unicode words, line breaks, and phrases. Empty entries and indented comments are ignored. Removed the check that applied the local account’s Quick Chat restriction to other players. |
| #117 — Switching to vanilla | Unpatches only BAU, cleans up registered extensions, and restores a 60 FPS target. The reported 20 FPS limit still needs testing. |
| #91 — Card swipe with unlocked FPS | Caps task minigames at 60 FPS and temporarily disables VSync. Restores VSync afterward. Unlocked gameplay now targets 165 FPS instead of 999 FPS. |
| #102 — Join bans | Initialization timeouts now respect the anti-cheat toggle. Timed-out players are kicked instead of permanently banned. Removed the fallback that overwrote remote player names and cosmetics. |
| #111 — Grey locked on Epic | Fixed palette bounds, duplicate favourite-colour callbacks, and leftover indicators. The Epic-specific colour lock remains unconfirmed. |
| #114 — Birth date/name reset/voting | Unresolved. No account files or age checks were changed. |
| #121 — Additional options | Not included in this PR. |
